### PR TITLE
[Token] Change parsing methods for types

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ std::vector<std::string> split_type(std::string const& s) {
 }
 
 std::optional<ws::parser::TokenType> parse_type(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
     if (s == "parenthesis")
         return ws::parser::TokenType::Parenthesis;
     if (s == "operator")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,20 @@
 #include <iostream>
 #include <cctype>
 #include <optional>
+#include <sstream>
 
 #include <ws/Module.hpp>
 #include <json.hpp>
 #include <ws/parser/Parser.hpp>
+
+std::vector<std::string> split_type(std::string const& s) {
+    std::stringstream stream(s);
+    std::vector<std::string> types;
+    std::string type;
+    while(std::getline(stream, type, '.'))
+        types.emplace_back(type);
+    return types;
+}
 
 std::optional<ws::parser::TokenType> parse_type(std::string s) {
     std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
@@ -41,16 +51,24 @@ std::optional<ws::parser::TokenSubType> parse_subtype(std::string s) {
 std::vector<ws::parser::Token> parse_tokens(nlohmann::json const& json) {
     std::vector<ws::parser::Token> tokens;
     for(auto json_token : json) {
-        auto type = parse_type(json_token["type"].get<std::string>());
-        auto subtype = parse_subtype(json_token["subtype"].get<std::string>());
+        auto raw_type = json_token["type"].get<std::string>();
+        auto types = split_type(raw_type);
+        if (types.size() != 2) {
+            ws::println("Couldn't parse type ", raw_type);
+            return {};
+        }
+
+        auto type = parse_type(types[0]);
+        auto subtype = parse_subtype(types[1]);
         if (!type) {
-            ws::println("Couldn't parse `",json_token["type"].get<std::string>(), "`");
+            ws::println("Type ", types[0], " is not known");
             return {};
         }
         if (!subtype) {
-            ws::println("Couldn't parse `",json_token["subtype"].get<std::string>(), "`");
+            ws::println("Subtype ", types[1], " is not known");
             return {};
         }
+        
         tokens.emplace_back(json_token["content"].get<std::string>(), *type, *subtype);
     }
     return tokens;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,7 @@ std::optional<ws::parser::TokenType> parse_type(std::string s) {
         return ws::parser::TokenType::Parenthesis;
     if (s == "operator")
         return ws::parser::TokenType::Operator;
-    if (s == "litteral")
+    if (s == "literal")
         return ws::parser::TokenType::Literal;
 
     return std::nullopt;


### PR DESCRIPTION
- rename `litteral` to `literal`
- parse `type` as multiple types separated by `.` instead of two attributes `type` and `subtype` 